### PR TITLE
Cap image tag length at 128 chars

### DIFF
--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -29,7 +29,7 @@ function createTag() {
   local repositoryName="$2"
   local imageTag="$3"
   local newImageTag
-  newImageTag="$(echo -n "$4" | tr -s -c '[:alnum:][\_]' -)"
+  newImageTag="$(echo -n "$4" | tr -s -c '[:alnum:][\_]' - | cut -c 1-128)"
 
   local manifest
   local result


### PR DESCRIPTION
## Change

Avoid plugin errors when image tag is longer than 128 symbols
