### PR TITLE
PEAKONDEVEX-979: Ignore ImageAlreadyExistsException regardless of exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run lint
-      run: docker-compose run --rm lint
-    - name: Run shellcheck
-      run: docker-compose run --rm shellcheck
+      - uses: actions/checkout@v2
+      - name: Run lint
+        run: docker compose run --rm lint
+      - name: Run shellcheck
+        run: docker compose run --rm shellcheck

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Add the following to your `pipeline.yml`:
 steps:
   - key: tag-docker-image-ecr
     plugins:
-      - peakon/ecr-tag#v0.0.4:
+      - peakon/ecr-tag#v0.0.5:
           registry-id: ${AWS_ACCOUNT_ID}
           repository: ${BUILDKITE_PIPELINE_NAME}
           tag: ${BUILDKITE_COMMIT}
           new-tags:
-          - ${BUILDKITE_BRANCH}-${BUILDKITE_COMMIT}
-          - ${BUILDKITE_BRANCH}
+            - ${BUILDKITE_BRANCH}-${BUILDKITE_COMMIT}
+            - ${BUILDKITE_BRANCH}
 ```
+
 ## Requirements
 
 - AWS cli, jq
@@ -27,12 +28,12 @@ steps:
 
 ## Configuration
 
-| property | description |
-| ---------|-------------|
+| property    | description                      |
+| ----------- | -------------------------------- |
 | registry-id | ECR registry ID (AWS account id) |
-| repository  | ECR repository name |
-| tag | Existing docker image tag |
-| new-tags | Array of tags to be created |
+| repository  | ECR repository name              |
+| tag         | Existing docker image tag        |
+| new-tags    | Array of tags to be created      |
 
 ### AWS profiles
 
@@ -46,7 +47,8 @@ You can specify a custom AWS profile to be used by AWS CLI
 To run the tests:
 
 ```shell
-docker-compose run --rm tests
+docker compose run --rm lint
+docker compose run --rm shellcheck
 ```
 
 ## Contributing
@@ -56,4 +58,4 @@ docker-compose run --rm tests
 3. Run shellcheck and plugin lint
 4. Commit and push your changes
 5. Send a pull request
->>>>>>> 8aa7528 (Initial commit)
+   > > > > > > > 8aa7528 (Initial commit)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tests:
     image: buildkite/plugin-tester
@@ -7,7 +5,7 @@ services:
       - ".:/plugin:ro"
   lint:
     image: buildkite/plugin-linter
-    command: ['--id', 'peakon/ecr-tag']
+    command: ["--id", "peakon/ecr-tag"]
     volumes:
       - ".:/plugin:ro"
   shellcheck:

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -50,12 +50,10 @@ function createTag() {
   set -e
   if [ "${exit_code}" -ne 0 ]; then
     echo "${result}"
-    if [ "${exit_code}" -eq 255 ]; then # https://docs.aws.amazon.com/cli/latest/topic/return-codes.html
-      if [[ "${result}" =~ .*"ImageAlreadyExistsException".* ]]; then
+    if [[ "${result}" =~ .*"ImageAlreadyExistsException".* ]]; then
         echo "Image tag ${newImageTag} already exist. Skipping..."
-      fi
     else
-      exit "${exit_code}"
+      exit "${exit_code}" # https://docs.aws.amazon.com/cli/latest/topic/return-codes.html
     fi
   else
     echo "Successfully retagged image: ${newImageTag}"


### PR DESCRIPTION
## Change

Ignore `ImageAlreadyExistsException` no matter what exit code.

## Problem / Why

https://buildkite.com/peakon/activity/builds/82#01956c1e-92b9-48ab-83cf-0ed41c1164b9/391-402
Looking at the code it looks like we want to ignore `ImageAlreadyExistsException`, but only when we get error 255.
and looking at the build log it looks like we got 254.

## References

- https://jira2.workday.com/browse/PEAKONDEVEX-979
- https://workday-dev.slack.com/archives/C02U2NZGB6E/p1741339473697039
